### PR TITLE
Move dependencies from build-system requires to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["streamlit", "streamlit-extras", "faker", "matplotlib", "setuptools>=61.0"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,6 +14,12 @@ license = { file="LICENSE" }
 requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "streamlit",
+    "streamlit-extras",
+    "faker",
+    "matplotlib",
 ]
 keywords = [
     "python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "streamlit_faker"
-version = "0.0.1"
+version = "0.0.2"
 authors = [
   { name="Arnaud Miribel", email="arnaudmiribel@gmail.com" },
 ]


### PR DESCRIPTION
Without this, the package is unusable, as it doesn't include faker, extras, etc. -- those are only used in the build, but not added to the package.