### PR TITLE
Remove streamlit-extras from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-streamlit-extras
 faker
 matplotlib
 streamlit-faker==0.0.3


### PR DESCRIPTION
Right now, streamlit-extras fails to install to Bazel environments because of a cyclic dependency (streamlit-extras depends on streamlit-faker; streamlit-faker depends on streamlit-extras). Because streamlit-extras is the higher-level of the two, this dependency should be removed and replaced with any specific sub-dependencies that might be necessary to make streamlit-faker work